### PR TITLE
Added BuildSettings property to build Xcode project with custom settings

### DIFF
--- a/src/Cake.XCode.Tests/Test.cs
+++ b/src/Cake.XCode.Tests/Test.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Cake.CocoaPods;
 using Cake.Common.IO;
@@ -21,7 +21,7 @@ namespace Cake.XCode.Tests
             //context.CakeContext.CleanDirectories("./TestProjects/**/obj");
 
             if (context.CakeContext.DirectoryExists ("./TestProjects/tmp"))
-                context.CakeContext.DeleteDirectory ("./TestProjects/tmp", true);
+                context.CakeContext.DeleteDirectory ("./TestProjects/tmp", new DeleteDirectorySettings { Recursive = true });
 
             context.CakeContext.CreateDirectory ("./TestProjects/tmp");
         }
@@ -128,7 +128,12 @@ namespace Cake.XCode.Tests
                 Arch = "i386",
                 Configuration = "Release",
                 DerivedDataPath = "./TestProjects/tmp/build",
-                Clean = true
+                Clean = true,
+                BuildSettings = new Dictionary<string, string>
+                {
+                    { "ENABLE_BITCODE", "YES" },
+                    { "BITCODE_GENERATION_MODE", "bitcode" },
+                }
             });
 
             Assert.True (context.CakeContext.DirectoryExists ("./TestProjects/tmp/build/Build/"));

--- a/src/Cake.XCode/XCodeBuildRunner.cs
+++ b/src/Cake.XCode/XCodeBuildRunner.cs
@@ -227,6 +227,12 @@ namespace Cake.XCode
         /// <value>The export language.</value>
         public string ExportLanguage { get; set; }
 
+		/// <summary>
+		/// Overrides specified build settings or adds User-Defined build settings
+		/// </summary>
+		/// <value>The build settings key value pairs.</value>
+		public Dictionary<string, string> BuildSettings { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether project should be cleaned.
         /// </summary>
@@ -408,6 +414,8 @@ namespace Cake.XCode
             if (settings.Clean)
                 builder.Append ("clean");
 
+			if (settings.BuildSettings != null && settings.BuildSettings.Count > 0)
+				builder.Append(string.Join(" ", settings.BuildSettings.Select(kvp => string.Format("{0}={1}", kvp.Key, kvp.Value))));
 
             Run (settings, builder, settings.ToolPath);
         }


### PR DESCRIPTION
* This closes #10

<!--- Provide a general summary of your changes in the Title above -->
This adds a property named `BuildSettings` that passes build settings as arguments in `xcodebuild` command line. This is an alternative option of `XcConfig` option. Now you can use it as:

```csharp
XCodeBuild (new XCodeBuildSettings {
	Project = project,
	Target = target,
	BuildSettings = new Dictionary<string, string>
	{
		{ "KEY", "Value" },
	}
});
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
