### PR TITLE
Add missing option for run tests with XCodeBuild

### DIFF
--- a/src/Cake.XCode/XCodeBuildRunner.cs
+++ b/src/Cake.XCode/XCodeBuildRunner.cs
@@ -60,6 +60,11 @@ namespace Cake.XCode
         public string Target { get; set; }
 
         /// <summary>
+        /// Run tests with xcodebuild
+        /// </summary>
+        public bool Test { get; set; }
+
+        /// <summary>
         /// Builds all the targets
         /// </summary>
         public bool AllTargets { get; set; }
@@ -400,7 +405,10 @@ namespace Cake.XCode
             if (!string.IsNullOrEmpty (settings.ExportLanguage))
                 builder.Append ("-exportLanguage " + settings.ExportLanguage);
 
-            if(settings.Archive)
+            if (settings.Test)
+                builder.Append("test");
+
+            if (settings.Archive)
                 builder.Append("archive");
             else
                 builder.Append ("build");


### PR DESCRIPTION
Add 'test' option for running tests.

## Description
Add new bool option to builder.
 
## Related Issue
https://github.com/cake-contrib/Cake.XCode/issues/20#issue-1338808525

## How Has This Been Tested?
In my project its work perfect.

## Screenshots (if appropriate):
<img width="772" alt="image" src="https://user-images.githubusercontent.com/48021947/184620234-ce11a6cf-067f-4223-bb12-46fb950a9343.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
